### PR TITLE
Add app's backfaceVisibility class to all actor surfaces. Fixes issue in...

### DIFF
--- a/app/src/tools/ActorFactory.js
+++ b/app/src/tools/ActorFactory.js
@@ -16,7 +16,8 @@ define(function(require, exports, module) {
             newSurface = new Surface({
                 size: size,
                 content: content,
-                properties: properties
+                properties: properties,
+                classes: ['backfaceVisibility']
             });
         }
 
@@ -24,7 +25,8 @@ define(function(require, exports, module) {
             newSurface = new ImageSurface({
                 size: size,
                 content: content,
-                properties: properties
+                properties: properties,
+                classes: ['backfaceVisibility']
             });
         }
 
@@ -38,7 +40,7 @@ define(function(require, exports, module) {
 
     ActorFactory.prototype.getActor = function(name) {
         return this.actors[name];
-    }
+    };
 
     module.exports = ActorFactory;
 });


### PR DESCRIPTION
... webkit browsers that require prefix for backface visibility.
