### PR TITLE
Remove call to grunt-rev which adds a randomized cache buster string to ...

### DIFF
--- a/grunt/aliases.js
+++ b/grunt/aliases.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
     'cssmin',
     'uglify',
     'copy:dist',
-    'rev',
+    // 'rev', <-- inserts cache buster into file names. Not need to distribute as component
     'usemin',
     'htmlmin'
   ]);


### PR DESCRIPTION
...js and css file names. This isn't needed to distribute as a component.
