### PR TITLE
Removed speed factor for touch screens. Fixed keyboard breaks.

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -729,7 +729,7 @@ define(function(require, exports, module) {
         {
             actor: 'How It Works',
             start: 22001,
-            stop: 24000,
+            stop: 23000,
             type: 'moveTo',
             properties: {
                 location: ['50%', '-30%']
@@ -755,11 +755,6 @@ define(function(require, exports, module) {
             }
         }
     ];
-
-    for (var i = 0; i < actionDescriptions.length; i++) {
-        actionDescriptions[i].start = Math.floor(actionDescriptions[i].start / 4);
-        actionDescriptions[i].stop = Math.floor(actionDescriptions[i].stop / 4);
-    }
 
     director.populateStage(stageView, actorDescriptions, actionDescriptions);
 

--- a/app/src/views/StageView.js
+++ b/app/src/views/StageView.js
@@ -23,7 +23,7 @@ define(function(require, exports, module) {
 
         _setupScrollRecieverSurface.call(this);
         _handleScroll.call(this);
-        _setupArrowKeyBreakpoints.call(this, [250, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3250, 3500, 3750, 4000, 4250, 4500, 4750, 5000, 5250, 5500, 5750, 6000]);
+        _setupArrowKeyBreakpoints.call(this, [1000, 2000, 3000, 4000, 5000, 7000, 8000, 9000, 11000, 12000, 13000, 14000, 15000, 16000, 17000, 18000, 19000, 20000, 21000, 22000, 23000, 24000], 16, 60);
     }
 
     StageView.DEFAULT_OPTIONS = {


### PR DESCRIPTION
Original web demo was algorithmically sped up by a factor of 4 to deal with slow scrolling on iOS. This math caused alignment problems with the originally established keyboard break points. 

I removed the speed factor. (Demo may run slower on iOS.) Also fixed the breakpoints for better alignment. Also did this in preparation for refactoring how the keyboard breakpoints will get set in library.

Tested on latest Chrome and Safari.